### PR TITLE
fix: prevent implicit any errors

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useRef } from "react";
+import React, { useState, useContext, useRef, PropsWithChildren } from "react";
 import { get, set } from "lodash";
 import produce from "immer";
 
@@ -57,7 +57,7 @@ export function StateTreeProvider<StateTreeType extends Object>({
   );
 }
 
-export function StateKey({ value, children }) {
+export function StateKey({ value, children }: PropsWithChildren<{ value: string | number }>) {
   const parentPath = useContext(StateTreePath);
 
   return (
@@ -67,7 +67,7 @@ export function StateKey({ value, children }) {
   );
 }
 
-export function StateListKey({ value, children }) {
+export function StateListKey({ value, children }: PropsWithChildren<{ value: string | number }>) {
   return (
     <StateKey value={value}>
       {React.Children.map(children, (child, index) => {
@@ -86,9 +86,9 @@ export function useEntireStateTree() {
   return { stateTree, replaceStateTree };
 }
 
-let defaultStateTreeKey = null;
+let defaultStateTreeKey: string | number | null = null;
 
-export function nextStateTreeKey(nextKey) {
+export function nextStateTreeKey(nextKey: string | number) {
   defaultStateTreeKey = nextKey;
 }
 
@@ -134,7 +134,7 @@ export function useStateTree<T>(
 
   const targetPath = stateTreePath.concat(keyRef.current);
 
-  const updateState = (nextValue) => {
+  const updateState = (nextValue: T) => {
     replaceStateTree(
       produce(stateTree, (draft) => {
         set(draft, targetPath, nextValue);


### PR DESCRIPTION
I ran into compilation errors when using this module in a plain create-react-app typescript setup.
When adding these types it compiles and works as expected, and i figured this might help others as well.

Please let me know if these changes are incorrect!