### PR TITLE
Allow React.SetStateAction, and state factory patterns for better dro…

### DIFF
--- a/index.test.tsx
+++ b/index.test.tsx
@@ -57,6 +57,52 @@ Object {
 `);
 });
 
+test("basic usage with factories", () => {
+  function Counter({ id }: { id: string }) {
+    const [count, setCount] = useStateTree(() => 0);
+
+    return (
+      <button data-testid={id} onClick={() => setCount((count) => count + 1)}>
+        Count: {count}
+      </button>
+    );
+  }
+
+  let state = {};
+
+  const app = render(
+    <StateTreeProvider
+      initialValue={state}
+      onUpdate={(newState) => (state = newState)}
+    >
+      <Counter id="first" />
+      <Counter id="second" />
+    </StateTreeProvider>
+  );
+
+  expect(app.container.innerHTML).toMatchInlineSnapshot(
+    `"<button data-testid=\\"first\\">Count: 0</button><button data-testid=\\"second\\">Count: 0</button>"`
+  );
+
+  const firstButton = app.getByTestId("first");
+  const secondButton = app.getByTestId("second");
+
+  fireEvent.click(firstButton);
+  fireEvent.click(firstButton);
+
+  fireEvent.click(secondButton);
+
+  expect(app.container.innerHTML).toMatchInlineSnapshot(
+    `"<button data-testid=\\"first\\">Count: 2</button><button data-testid=\\"second\\">Count: 1</button>"`
+  );
+  expect(state).toMatchInlineSnapshot(`
+Object {
+  "$0": 2,
+  "$1": 1,
+}
+`);
+});
+
 test("user-specified keys in useStateTree call", () => {
   function Counter({ id }: { id: string }) {
     const [count, setCount] = useStateTree(0, id);


### PR DESCRIPTION
…p in replacement api compatibility

Stating that this is a `drop in replacement` for set state proved to be... a lie.

Often, to escape render loops when using object based state and exhaustive-deps, you cannot allow the state to be referenced in the `useEffect`, so you need the `React.SetStateAction` that allows current to be passed in for spreading and then overlaying changes.

Also, react's `setState` allows a factory to be used.

Tests included.